### PR TITLE
Fixing express warning "express: app.del: Use app.delete instead"

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -294,7 +294,7 @@ Router.prototype.resource = function(name, options, fn) {
         break;
       case 'update':  self._route('put' , path                   , controller, 'update' );
         break;
-      case 'destroy': self._route('del' , path                   , controller, 'destroy');
+      case 'destroy': self._route('delete' , path                   , controller, 'destroy');
         break;
     }
   });

--- a/lib/router.js
+++ b/lib/router.js
@@ -389,7 +389,7 @@ Router.prototype.resources = function(name, options, fn) {
         break;
       case 'update':  self._route('put' , path + '/' + param                   , controller, 'update' );
         break;
-      case 'destroy': self._route('del' , path + '/' + param                   , controller, 'destroy');
+      case 'destroy': self._route('delete' , path + '/' + param                   , controller, 'destroy');
         break;
     }
   });


### PR DESCRIPTION
This appears to be cause by Express 3.6.0+
https://github.com/visionmedia/express/releases/tag/3.6.0
